### PR TITLE
chore(dsfr): utilise la configuration conseillée pour intégrer le DSFR à Vite

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,11 +4,23 @@
     <meta charset="utf-8" />
 
     <link rel="manifest" href="/manifest.json" />
-    <link rel="apple-touch-icon" href="/dsfr/favicon/apple-touch-icon.png?v=1.12.1" />
-    <link rel="icon" href="/dsfr/favicon/favicon.svg?v=1.12.1" type="image/svg+xml" />
-    <link rel="shortcut icon" href="/dsfr/favicon/favicon.ico?v=1.12.1" type="image/x-icon" />
-    <link rel="stylesheet" href="/dsfr/utility/icons/icons.min.css?hash=e44afab5" />
-    <link rel="stylesheet" href="/dsfr/dsfr.min.css?v=1.12.1" />
+    <link rel="apple-touch-icon" href="./node_modules/@codegouvfr/react-dsfr/favicon/apple-touch-icon.png" />
+    <link rel="icon" href="./node_modules/@codegouvfr/react-dsfr/favicon/favicon.svg" type="image/svg+xml" />
+    <link rel="shortcut icon" href="./node_modules/@codegouvfr/react-dsfr/favicon/favicon.ico" type="image/x-icon" />
+
+    <!--<link rel="preload" href="./node_modules/@codegouvfr/react-dsfr/dsfr/fonts/Marianne-Light.woff2" as="font" crossorigin="anonymous" />-->
+    <!--<link rel="preload" href="./node_modules/@codegouvfr/react-dsfr/dsfr/fonts/Marianne-Light_Italic.woff2" as="font" crossorigin="anonymous" />-->
+    <link rel="preload" href="./node_modules/@codegouvfr/react-dsfr/dsfr/fonts/Marianne-Regular.woff2" as="font" crossorigin="anonymous" />
+    <!--<link rel="preload" href="./node_modules/@codegouvfr/react-dsfr/dsfr/fonts/Marianne-Regular_Italic.woff2" as="font" crossorigin="anonymous" />-->
+    <link rel="preload" href="./node_modules/@codegouvfr/react-dsfr/dsfr/fonts/Marianne-Medium.woff2" as="font" crossorigin="anonymous" />
+    <!--<link rel="preload" href="./node_modules/@codegouvfr/react-dsfr/dsfr/fonts/Marianne-Medium_Italic.woff2" as="font" crossorigin="anonymous" />-->
+    <link rel="preload" href="./node_modules/@codegouvfr/react-dsfr/dsfr/fonts/Marianne-Bold.woff2" as="font" crossorigin="anonymous" />
+    <!--<link rel="preload" href="./node_modules/@codegouvfr/react-dsfr/dsfr/fonts/Marianne-Bold_Italic.woff2" as="font" crossorigin="anonymous" />-->
+    <!--<link rel="preload" href="./node_modules/@codegouvfr/react-dsfr/dsfr/fonts/Spectral-Regular.woff2" as="font" crossorigin="anonymous" />-->
+    <!--<link rel="preload" href="./node_modules/@codegouvfr/react-dsfr/dsfr/fonts/Spectral-ExtraBold.woff2" as="font" crossorigin="anonymous" />-->
+
+
+    <link rel="stylesheet" href="./node_modules/@codegouvfr/react-dsfr/main.css" />
     <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4.1.2/dist/maplibre-gl.css" />
 
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -19,13 +31,9 @@
     />
     <title>maestro</title>
 
-    <link rel="preload" href="/dsfr/fonts/Marianne-Regular.woff2?v=1.12.1" as="font" crossorigin="anonymous" />
-    <link rel="preload" href="/dsfr/fonts/Marianne-Medium.woff2?v=1.12.1" as="font" crossorigin="anonymous" />
-    <link rel="preload" href="/dsfr/fonts/Marianne-Bold.woff2?v=1.12.1" as="font" crossorigin="anonymous" />
-
-  <script type="module" src="src/index"></script></head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <script type="module" src="src/index.tsx"></script></head>
   </body>
 </html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,6 @@
     "preview": "vite preview",
     "test": "vitest",
     "lint": "node_modules/.bin/eslint . --ext .ts,.tsx",
-    "postinstall": "copy-dsfr-to-public",
     "predev": "react-dsfr update-icons",
     "prestart": "react-dsfr update-icons",
     "prebuild": "react-dsfr update-icons"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,15 +3,16 @@
   "version": "0.0.1",
   "private": false,
   "scripts": {
+    "dev": "vite",
     "start": "vite",
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest",
     "lint": "node_modules/.bin/eslint . --ext .ts,.tsx",
     "postinstall": "copy-dsfr-to-public",
-    "prestart": "only-include-used-icons",
-    "prebuild": "only-include-used-icons",
-    "dev": "vite"
+    "predev": "react-dsfr update-icons",
+    "prestart": "react-dsfr update-icons",
+    "prebuild": "react-dsfr update-icons"
   },
   "license": "AGPL-3.0",
   "engines": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,9 +20,9 @@ declare module '@codegouvfr/react-dsfr/spa' {
     Link: typeof Link;
   }
 }
+startReactDsfr({ defaultColorScheme: 'light', Link });
 
 function AppWrapper() {
-  startReactDsfr({ defaultColorScheme: 'light', Link });
 
   const { MuiDsfrThemeProvider } = createMuiDsfrThemeProvider({
     augmentMuiTheme: ({ nonAugmentedMuiTheme }) => ({


### PR DESCRIPTION
Maintenant que nous sommes sur Vite, j'ai pu utiliser la configuration conseillée en recopiant https://github.com/garronej/react-dsfr-vite-demo

Le fichier `index.html` ne bouge plus :-)