### PR TITLE
fix(): corrige les espaces insécables

### DIFF
--- a/frontend/src/components/Prescription/RegionalPrescriptionCommentsModal/RegionalPrescriptionCommentAuthor.tsx
+++ b/frontend/src/components/Prescription/RegionalPrescriptionCommentsModal/RegionalPrescriptionCommentAuthor.tsx
@@ -15,7 +15,7 @@ const RegionalPrescriptionCommentAuthor = ({ userId }: Props) => {
       <b>
         {user?.firstName} {user?.lastName}
       </b>
-       - {user?.roles.map((role) => UserRoleLabels[role]).join(', ')} 
+       - {user?.roles.map((role) => UserRoleLabels[role]).join(', ')}{' '}
       {user?.region ? Regions[user.region].name : ''}
     </div>
   );

--- a/frontend/src/views/SampleView/DraftSample/ContextStep/ContextStep.tsx
+++ b/frontend/src/views/SampleView/DraftSample/ContextStep/ContextStep.tsx
@@ -418,7 +418,7 @@ const ContextStep = ({ partialSample }: Props) => {
             )}
           >
             <span className="missing-data">
-              Entité saisie hors ligne à compléter : 
+              Entité saisie hors ligne à compléter :{' '}
             </span>
             {companyOffline}
           </div>

--- a/frontend/src/views/SampleView/DraftSample/SupportDocumentDownload.tsx
+++ b/frontend/src/views/SampleView/DraftSample/SupportDocumentDownload.tsx
@@ -65,7 +65,7 @@ const SupportDocumentDownload = ({
           iconId="fr-icon-printer-fill"
         >
           <div>
-            Générer le document 
+            Générer le document{' '}
             {isMobile && <br />}
             d'accompagnement
           </div>
@@ -95,7 +95,7 @@ const SupportDocumentDownload = ({
         >
           <b>
             Vous vous apprêtez à imprimer un document d’accompagnement
-            incomplet. 
+            incomplet.{' '}
           </b>
           {!isCreatedPartialSample(partialSample)
             ? 'Le prélèvement va être créé mais votre '

--- a/frontend/src/views/SampleView/SampleAnalysis/SampleAdmissibility/SampleAdmissibility.tsx
+++ b/frontend/src/views/SampleView/SampleAnalysis/SampleAdmissibility/SampleAdmissibility.tsx
@@ -249,7 +249,7 @@ const SampleAdmissibility = ({ sample }: Props) => {
           {sample.receivedAt ? (
             <>
               <div className={cx('fr-text--md', 'fr-text--regular')}>
-                Prélèvement reçu par le laboratoire le 
+                Prélèvement reçu par le laboratoire le{' '}
                 {format(sample.receivedAt, 'dd MMMM yyyy', { locale: fr })}
               </div>
               <div>

--- a/frontend/src/views/SampleView/StepSummary/ContextStepSummary.tsx
+++ b/frontend/src/views/SampleView/StepSummary/ContextStepSummary.tsx
@@ -39,7 +39,7 @@ const ContextStepSummary = ({
       <div className="summary-item icon-text">
         <div className={cx('fr-icon-user-line')}></div>
         <div>
-          Prélèvement réalisé par 
+          Prélèvement réalisé par{' '}
           <b>
             {isCreatedSample(sample)
               ? `${sample.sampler.firstName} ${sample.sampler.lastName}`


### PR DESCRIPTION
On ne voit pas trop sur la review, mais j'ai juste encapsulé les espaces insécables dans des {}.
Tous les espaces insécables en fin de ligne de template ne fonctionnaient pas.