### PR TITLE
fix(sécurité): améliore les Content Security Policy (CSP)

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -32,17 +32,17 @@ export function createServer(): Server {
       crossOriginEmbedderPolicy: false,
       contentSecurityPolicy: {
         directives: {
-          defaultSrc: ["'self'"],
+          defaultSrc: ["'none'"],
           scriptSrc: [
             "'self'",
-            "'unsafe-inline'",
             'https://stats.beta.gouv.fr',
           ],
           frameSrc: [],
           styleSrc: [
             "'self'",
-            "'unsafe-inline'",
-            'https://unpkg.com/maplibre-gl@4.1.2/dist/maplibre-gl.css',
+            "https://unpkg.com/maplibre-gl@4.1.2/dist/maplibre-gl.css",
+            // https://github.com/mui/material-ui/issues/19938
+            "'unsafe-inline'"
           ],
           imgSrc: ["'self'", 'https://stats.beta.gouv.fr', 'data:'],
           fontSrc: ["'self'", 'data:'],
@@ -58,6 +58,7 @@ export function createServer(): Server {
             `https://${config.s3.client.endpoint.split('//')[1]}`
           ],
           workerSrc: ["'self'", 'blob:'],
+          manifestSrc: ["'self'"]
         },
       },
     })


### PR DESCRIPTION
Pas parfait mais mieux => https://developer.mozilla.org/fr/observatory/analyze?host=maestro-staging-pr102.osc-fr1.scalingo.io#csp

Tu peux tester ici => https://maestro-staging-pr102.osc-fr1.scalingo.io/

Pour info, on a déjà un truc de bloqué par une CSP en prod, donc je ne l'ai pas autorisé sur cette PR =>
`Content-Security-Policy : Les paramètres de la page ont empêché l’exécution d’un script (script-src-elem) à l’adresse https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.3/mapbox-gl-rtl-text.js`