### PR TITLE
refactor(emails): type les paramètres pour les templates d'emails

### DIFF
--- a/server/controllers/sampleController.ts
+++ b/server/controllers/sampleController.ts
@@ -320,7 +320,8 @@ const updateSample = async (request: Request, response: Response) => {
               }))
           );
 
-          await mailService.sendAnalysisRequest({
+          await mailService.send({
+            templateName: 'SampleAnalysisRequestTemplate',
             recipients: [laboratory?.email, config.mail.from],
             params: {
               region: user.region ? Regions[user.region].name : undefined,
@@ -345,7 +346,8 @@ const updateSample = async (request: Request, response: Response) => {
         }
 
         if (sample.ownerEmail) {
-          await mailService.sendSupportDocumentCopyToOwner({
+          await mailService.send({
+            templateName: 'SupportDocumentCopyToOwnerTemplate',
             recipients: [sample.ownerEmail, config.mail.from],
             params: {
               region: user.region ? Regions[user.region].name : undefined,

--- a/server/services/mailService/brevoService.ts
+++ b/server/services/mailService/brevoService.ts
@@ -1,12 +1,6 @@
 import * as Brevo from '@getbrevo/brevo';
 import config from '../../utils/config';
-import { MailService, SendOptions } from './mailService';
-
-const SampleAnalysisRequestTemplateId = 1;
-const SupportDocumentCopyToOwnerTemplateId = 2;
-const SubmittedProgrammingPlanTemplateId = 3;
-const ValidatedProgrammingPlanTemplateId = 4;
-const NewRegionalPrescriptionCommentTemplateId = 5;
+import { MailService, SendOptions, TemplateName, Templates } from './mailService';
 
 class BrevoService implements MailService {
   private emailsApi: Brevo.TransactionalEmailsApi;
@@ -23,53 +17,16 @@ class BrevoService implements MailService {
     );
   }
 
-  async send(options: SendOptions): Promise<void> {
+  async send<T extends TemplateName>(options: SendOptions<T>): Promise<void> {
     await this.emailsApi.sendTransacEmail({
       ...options,
-      templateId: Number(options.templateId),
+      templateId: Templates[options.templateName].id,
       to: options.recipients.map((recipient) => ({
         email: recipient
       }))
     });
   }
 
-  async sendAnalysisRequest(options: SendOptions): Promise<void> {
-    return this.send({
-      ...options,
-      templateId: SampleAnalysisRequestTemplateId,
-      params: options.params
-    });
-  }
-
-  async sendSupportDocumentCopyToOwner(options: SendOptions): Promise<void> {
-    return this.send({
-      ...options,
-      templateId: SupportDocumentCopyToOwnerTemplateId
-    });
-  }
-
-  async sendSubmittedProgrammingPlan(options: SendOptions): Promise<void> {
-    return this.send({
-      ...options,
-      templateId: SubmittedProgrammingPlanTemplateId
-    });
-  }
-
-  async sendValidatedProgrammingPlan(options: SendOptions): Promise<void> {
-    return this.send({
-      ...options,
-      templateId: ValidatedProgrammingPlanTemplateId
-    });
-  }
-
-  async sendNewRegionalPrescriptionComment(
-    options: SendOptions
-  ): Promise<void> {
-    return this.send({
-      ...options,
-      templateId: NewRegionalPrescriptionCommentTemplateId
-    });
-  }
 }
 
 export default function createNodemailerService(): MailService {

--- a/server/services/mailService/fakeService.ts
+++ b/server/services/mailService/fakeService.ts
@@ -2,9 +2,4 @@ import { MailService } from './mailService';
 
 export const createFakeMailService = (): MailService => ({
   send: async () => {},
-  sendAnalysisRequest: async () => {},
-  sendNewRegionalPrescriptionComment: async () => {},
-  sendSubmittedProgrammingPlan: async () => {},
-  sendSupportDocumentCopyToOwner: async () => {},
-  sendValidatedProgrammingPlan: async () => {}
 });

--- a/server/services/mailService/mailService.ts
+++ b/server/services/mailService/mailService.ts
@@ -1,11 +1,45 @@
-export type TemplateId = string | number;
+import { z, ZodType } from 'zod';
 
-export interface SendOptions {
+export const Templates = {
+  SampleAnalysisRequestTemplate: {
+    id: 1,
+    params: z.object({
+      region: z.string().optional(),
+      userMail: z.string(),
+      sampledAt: z.string()
+    })
+  },
+  SupportDocumentCopyToOwnerTemplate: {
+    id: 2,
+    params: z.object({
+      region: z.string().optional(),
+      sampledAt: z.string()
+    })
+  },
+  SubmittedProgrammingPlanTemplate: { id: 3, params: z.undefined() },
+  ValidatedProgrammingPlanTemplate: { id: 4, params: z.undefined() },
+  NewRegionalPrescriptionCommentTemplate: {
+    id: 5,
+    params: z.object({
+      matrix: z.string(),
+      sampleCount: z.number(),
+      comment: z.string(),
+      author: z.string()
+    })
+  }
+} as const satisfies {
+  [templateName: string]: {
+    id: number;
+    params: ZodType;
+  };
+};
+
+export type TemplateName = keyof typeof Templates;
+
+export interface SendOptions<T extends TemplateName> {
   recipients: string[];
-  subject?: string;
-  content?: string;
-  templateId?: TemplateId;
-  params?: any;
+  templateName: T;
+  params: z.infer<(typeof Templates)[T]['params']>;
   attachment?: {
     content: string;
     name: string;
@@ -13,10 +47,5 @@ export interface SendOptions {
 }
 
 export interface MailService {
-  send(options: SendOptions): Promise<void>;
-  sendAnalysisRequest(options: SendOptions): Promise<void>;
-  sendSupportDocumentCopyToOwner(options: SendOptions): Promise<void>;
-  sendSubmittedProgrammingPlan(options: SendOptions): Promise<void>;
-  sendValidatedProgrammingPlan(options: SendOptions): Promise<void>;
-  sendNewRegionalPrescriptionComment(options: SendOptions): Promise<void>;
+  send<T extends TemplateName>(options: SendOptions<T>): Promise<void>;
 }

--- a/server/services/mailService/nodemailerService.ts
+++ b/server/services/mailService/nodemailerService.ts
@@ -1,7 +1,32 @@
 import nodemailer from 'nodemailer';
 import config from '../../utils/config';
-import { MailService, SendOptions } from './mailService';
+import { MailService, SendOptions, TemplateName } from './mailService';
 
+const TemplateData = {
+  SampleAnalysisRequestTemplate: {
+    subject: "Réception à venir d'un prélèvement",
+    content: `Vous allez bientôt recevoir un prélèvement`
+  },
+  SupportDocumentCopyToOwnerTemplate: {
+    subject: 'Copie du document d’accompagnement',
+    content: 'Voici une copie de votre document d’accompagnement'
+  },
+  SubmittedProgrammingPlanTemplate: {
+    subject: 'Plan de programmation',
+    content: 'Le plan de programmation a été soumis'
+  },
+  ValidatedProgrammingPlanTemplate: {
+    subject: 'Plan de programmation validé',
+    content: 'Le plan de programmation a été validé'
+  },
+  NewRegionalPrescriptionCommentTemplate: {
+    subject: 'Nouveau commentaire',
+    content: 'Un nouveau commentaire a été ajouté'
+  }
+} as const satisfies Record<TemplateName, {
+  subject: string,
+  content: string
+}>
 class NodemailerService implements MailService {
   private transport: nodemailer.Transporter<nodemailer.SentMessageInfo>;
 
@@ -17,58 +42,15 @@ class NodemailerService implements MailService {
     });
   }
 
-  async send(options: SendOptions): Promise<void> {
+  async send<T extends TemplateName>(options: SendOptions<T>): Promise<void> {
     return this.transport.sendMail({
       from: config.mail.from,
       to: options.recipients.join(','),
-      subject: options.subject,
-      html: options.content
-    });
-  }
-
-  async sendAnalysisRequest(options: SendOptions): Promise<void> {
-    return this.send({
-      ...options,
-      subject: "Réception à venir d'un prélèvement",
-      content: `Vous allez bientôt recevoir un prélèvement`
-    });
-  }
-
-  async sendSupportDocumentCopyToOwner(options: SendOptions): Promise<void> {
-    return this.send({
-      ...options,
-      subject: 'Copie du document d’accompagnement',
-      content: 'Voici une copie de votre document d’accompagnement'
-    });
-  }
-
-  async sendSubmittedProgrammingPlan(options: SendOptions): Promise<void> {
-    return this.send({
-      ...options,
-      subject: 'Plan de programmation',
-      content: 'Le plan de programmation a été soumis'
-    });
-  }
-
-  async sendValidatedProgrammingPlan(options: SendOptions): Promise<void> {
-    return this.send({
-      ...options,
-      subject: 'Plan de programmation validé',
-      content: 'Le plan de programmation a été validé'
-    });
-  }
-
-  async sendNewRegionalPrescriptionComment(
-    options: SendOptions
-  ): Promise<void> {
-    return this.send({
-      ...options,
-      subject: 'Nouveau commentaire',
-      content: 'Un nouveau commentaire a été ajouté'
+      subject: TemplateData[options.templateName].subject,
+      html: TemplateData[options.templateName].content
     });
   }
 }
-
 export default function createNodemailerService(): MailService {
   return new NodemailerService();
 }

--- a/server/services/notificationService.ts
+++ b/server/services/notificationService.ts
@@ -40,8 +40,9 @@ const sendNotification = async <T extends NotificationToCreate>(
   ) {
     const notification =
       NewRegionalPrescriptionCommentNotification.parse(notificationToCreate);
-    mailService.sendNewRegionalPrescriptionComment({
+    await mailService.send({
       recipients: recipients.map((recipient) => recipient.email),
+      templateName: 'NewRegionalPrescriptionCommentTemplate',
       params: {
         matrix: MatrixKindLabels[notification.matrixKind as MatrixKind],
         sampleCount: notification.sampleCount,
@@ -56,7 +57,9 @@ const sendNotification = async <T extends NotificationToCreate>(
   if (
     SubmittedProgrammingPlanNotification.safeParse(notificationToCreate).success
   ) {
-    await mailService.sendSubmittedProgrammingPlan({
+    await mailService.send({
+      templateName: 'SubmittedProgrammingPlanTemplate',
+      params: undefined,
       recipients: recipients.map((recipient) => recipient.email)
     });
   }
@@ -64,7 +67,9 @@ const sendNotification = async <T extends NotificationToCreate>(
   if (
     ValidatedProgrammingPlanNotification.safeParse(notificationToCreate).success
   ) {
-    await mailService.sendValidatedProgrammingPlan({
+    await mailService.send({
+      templateName: 'ValidatedProgrammingPlanTemplate',
+      params: undefined,
       recipients: recipients.map((recipient) => recipient.email)
     });
   }


### PR DESCRIPTION
Simplification du code pour avoir moins de boilerplate lors de l'ajout d'un nouveau template.
Mais surtout typage des params par template pour éviter les bétises.

À terme je pense qu'il faut remonter d'un cran via les notifications (par exemple je pense qu'entre `nodemailerService` et `notificationService` il y a des descriptions en commun)