### PR TITLE
fix(prélèvement): correction code département droms et corse

### DIFF
--- a/frontend/src/views/SampleView/DraftSample/ContextStep/ContextStep.tsx
+++ b/frontend/src/views/SampleView/DraftSample/ContextStep/ContextStep.tsx
@@ -127,7 +127,7 @@ const ContextStep = ({ partialSample }: Props) => {
   const formData = {
     id,
     sampledAt: parse(sampledAt, 'yyyy-MM-dd HH:mm', new Date()),
-    department: company?.postalCode?.slice(0, 2) as Department,
+    department: company?.department as Department,
     geolocation:
       geolocationX && geolocationY
         ? {
@@ -188,7 +188,7 @@ const ContextStep = ({ partialSample }: Props) => {
   const formInput = {
     id,
     sampledAt,
-    department: company?.postalCode?.slice(0, 2) as Department,
+    department: company?.department as Department,
     geolocationX,
     geolocationY,
     parcel,

--- a/server/database/migrations/038-company-department.ts
+++ b/server/database/migrations/038-company-department.ts
@@ -1,0 +1,25 @@
+import { Knex } from 'knex';
+
+export const up = async (knex: Knex) => {
+  await knex.schema.alterTable('companies', (table) => {
+    table.string('department');
+  });
+  await knex('companies').update({
+    department: knex.raw(
+      ` case when postal_code like '97%' then substring(postal_code, 1,3)
+        else substring(postal_code, 1,2)
+        end
+      `
+    )
+  });
+
+  await knex.schema.alterTable('companies', (table) => {
+    table.string('department').notNullable().alter();
+  });
+};
+
+export const down = async (knex: Knex) => {
+  await knex.schema.alterTable('companies', (table) => {
+    table.dropColumn('department');
+  });
+};

--- a/server/repositories/sampleRepository.ts
+++ b/server/repositories/sampleRepository.ts
@@ -36,6 +36,7 @@ const PartialSampleJoinedDbo = PartialSampleDbo.merge(
     companyAddress: z.string().nullish(),
     companyPostalCode: z.string().nullish(),
     companyCity: z.string().nullish(),
+    companyDepartment: z.string().nullish(),
     companyNafCode: z.string().nullish(),
     samplerId: z.string().uuid(),
     samplerFirstName: z.string(),
@@ -59,6 +60,7 @@ const findUnique = async (id: string): Promise<PartialSample | undefined> => {
       `${companiesTable}.address as company_address`,
       `${companiesTable}.postal_code as company_postal_code`,
       `${companiesTable}.city as company_city`,
+      `${companiesTable}.department as company_department`,
       `${companiesTable}.naf_code as company_naf_code`,
       `${usersTable}.id as sampler_id`,
       `${usersTable}.first_name as sampler_first_name`,
@@ -142,6 +144,7 @@ const findMany = async (
       `${companiesTable}.address as company_address`,
       `${companiesTable}.postal_code as company_postal_code`,
       `${companiesTable}.city as company_city`,
+      `${companiesTable}.department as company_department`,
       `${companiesTable}.naf_code as company_naf_code`,
       `${usersTable}.id as sampler_id`,
       `${usersTable}.first_name as sampler_first_name`,
@@ -293,6 +296,7 @@ export const parsePartialSample = (
           address: sample.companyAddress ?? undefined,
           postalCode: sample.companyPostalCode ?? undefined,
           city: sample.companyCity ?? undefined,
+          department: sample.companyDepartment ?? undefined,
           nafCode: sample.companyNafCode ?? undefined
         }
       : undefined,

--- a/shared/schema/Company/Company.ts
+++ b/shared/schema/Company/Company.ts
@@ -9,6 +9,7 @@ export const Company = z.object(
     address: z.string().nullish(),
     postalCode: z.string().nullish(),
     city: z.string().nullish(),
+    department: z.string(),
     nafCode: z.string().nullish()
   },
   {
@@ -36,6 +37,7 @@ export const companyFromSearchResult = (
       .join(' '),
     postalCode: companySearchResult.siege.code_postal,
     city: companySearchResult.siege.libelle_commune,
+    department: companySearchResult.siege.departement,
     nafCode: companySearchResult.activite_principale
   });
 
@@ -50,7 +52,7 @@ export const companyToSearchResult = (company: Company) =>
       adresse: company.address ?? '',
       code_postal: company.postalCode ?? '',
       commune: company.city ?? '',
-      departement: '',
+      departement: company.department ?? '',
       libelle_commune: company.city ?? '',
       libelle_voie: '',
       numero_voie: '',

--- a/shared/test/companyFixtures.ts
+++ b/shared/test/companyFixtures.ts
@@ -9,6 +9,7 @@ export const genCompany = (data?: Partial<Company>): Company => ({
   name: fakerFR.company.name(),
   address: faker.location.streetAddress({ useFullAddress: true }),
   postalCode: faker.location.zipCode(),
+  department: faker.location.zipCode().slice(0, 2),
   ...data
 });
 


### PR DESCRIPTION
Correction de l'alimentation automatique du code  département
Plutôt de que réécrire des règles pour déduire le code département à partit du code postal et de devoir gérer des cas particulier, récupération du code département retourné par l'API entreprise