### PR TITLE
fix(filtres): corrige le filtrage par conformité

### DIFF
--- a/frontend/src/components/SampleCard/SampleCard.tsx
+++ b/frontend/src/components/SampleCard/SampleCard.tsx
@@ -81,7 +81,7 @@ const SampleCard = ({ sample }: Props) => {
               ) : (
                 <>
                   {sample.companyOffline}
-                  <div className="missing-data">Information à compléter</div>
+                  <span className="missing-data">Information à compléter</span>
                 </>
               )}
             </span>
@@ -95,7 +95,7 @@ const SampleCard = ({ sample }: Props) => {
                 {sample.sampledAt ? (
                   format(sample.sampledAt, 'dd/MM/yyyy')
                 ) : (
-                  <div className="missing-data">Information à compléter</div>
+                  <span className="missing-data">Information à compléter</span>
                 )}
               </span>
               <span className="icon-text">
@@ -107,7 +107,7 @@ const SampleCard = ({ sample }: Props) => {
                     {DepartmentLabels[sample.department]} ({sample.department})
                   </>
                 ) : (
-                  <div className="missing-data">Information à compléter</div>
+                  <span className="missing-data">Information à compléter</span>
                 )}
               </span>
               <span className="icon-text">
@@ -117,7 +117,7 @@ const SampleCard = ({ sample }: Props) => {
                 {sample.context ? (
                   ContextLabels[sample.context]
                 ) : (
-                  <div className="missing-data">Information à compléter</div>
+                  <span className="missing-data">Information à compléter</span>
                 )}
               </span>
               {sample.matrixKind && (

--- a/frontend/src/views/SampleListView/SampleSecondaryFilters.tsx
+++ b/frontend/src/views/SampleListView/SampleSecondaryFilters.tsx
@@ -13,7 +13,8 @@ import {
 } from 'maestro-shared/schema/ProgrammingPlan/Context';
 import {
   FindSampleOptions,
-  SampleCompliance
+  SampleCompliance,
+  SampleComplianceLabels
 } from 'maestro-shared/schema/Sample/FindSampleOptions';
 import { useMemo } from 'react';
 import { useAuthentication } from 'src/hooks/useAuthentication';
@@ -125,8 +126,11 @@ const SampleSecondaryFilters = ({ filters, onChange }: Props) => {
           }}
         >
           <option value="">Tous</option>
-          <option value="conform">Conforme</option>
-          <option value="notConform">Non conforme</option>
+          {SampleCompliance.options.map((compliance) => (
+            <option key={`compliance-${compliance}`} value={compliance}>
+              {SampleComplianceLabels[compliance]}
+            </option>
+          ))}
         </Select>
       </div>
     </div>

--- a/server/repositories/sampleRepository.test.ts
+++ b/server/repositories/sampleRepository.test.ts
@@ -106,7 +106,8 @@ describe('findMany samples', async () => {
 
     samples = await sampleRepository.findMany({
       programmingPlanId: Sample11Fixture.programmingPlanId,
-      compliance: 'notConform'
+      compliance: 'notConform',
+      status: 'DraftMatrix'
     });
     expect(samples).toHaveLength(1);
     expect(samples[0].id).toBe(analysisKO.sampleId);

--- a/server/repositories/sampleRepository.ts
+++ b/server/repositories/sampleRepository.ts
@@ -115,19 +115,22 @@ const findRequest = (findOptions: FindSampleOptions) =>
       }
       if (findOptions.status) {
         if (isArray(findOptions.status)) {
-          builder.whereIn('status', findOptions.status);
+          builder.whereIn(`${samplesTable}.status`, findOptions.status);
         } else {
-          builder.where('status', findOptions.status);
+          builder.where(`${samplesTable}.status`, findOptions.status);
         }
       }
       if (findOptions.sampledAt) {
         builder.whereRaw(
-          `to_char(sampled_at, 'YYYY-MM-DD') = ?`,
+          `to_char(${samplesTable}.sampled_at, 'YYYY-MM-DD') = ?`,
           findOptions.sampledAt
         );
       }
       if (findOptions.reference) {
-        builder.whereILike('reference', `%${findOptions.reference}%`);
+        builder.whereILike(
+          `${samplesTable}.reference`,
+          `%${findOptions.reference}%`
+        );
       }
       if (findOptions.department) {
         builder.where(`${samplesTable}.department`, findOptions.department);

--- a/shared/schema/Sample/FindSampleOptions.ts
+++ b/shared/schema/Sample/FindSampleOptions.ts
@@ -7,7 +7,13 @@ import { Pagination } from '../commons/Pagination';
 import { Context } from '../ProgrammingPlan/Context';
 import { SampleStatus } from './SampleStatus';
 
-export const SampleCompliance = z.enum(['conform', 'notConform']).nullish();
+export const SampleCompliance = z.enum(['conform', 'notConform']);
+
+export const SampleComplianceLabels = {
+  conform: 'Conforme',
+  notConform: 'Non conforme'
+} as const satisfies Record<z.infer<typeof SampleCompliance>, string>;
+
 export const FindSampleOptions = z
   .object({
     programmingPlanId: z.string().uuid(),
@@ -21,7 +27,7 @@ export const FindSampleOptions = z
     sampledBy: z.string().uuid().nullish(),
     sampledAt: z.string().nullish(),
     reference: z.string().nullish(),
-    compliance: SampleCompliance
+    compliance: SampleCompliance.nullish()
   })
   .merge(Pagination.partial());
 


### PR DESCRIPTION
 - Type les tags pour éviter d'oublier de les coder à l'avenir
 - Corrige la requête
 - Supprime le warning dans les logs, on ne peut pas mettre de `<div>` dans la description d'une carte du DSFR