### PR TITLE
feat(déconnexion): ne met pas l'url de déconnexion dans le session storage

### DIFF
--- a/frontend/src/AppRoutes.tsx
+++ b/frontend/src/AppRoutes.tsx
@@ -115,10 +115,12 @@ export type NotAuthenticatedAppRoutes = keyof typeof NotAuthenticatedAppRoutes;
 export const RedirectRoute: FunctionComponent = ({ ..._rest }) => {
   assert<Equals<keyof typeof _rest, never>>();
 
-  sessionStorage.setItem(
-    SESSION_STORAGE_REDIRECT_URL,
-    window.location.pathname
-  );
+  if (window.location.pathname !== '/logout-callback') {
+    sessionStorage.setItem(
+      SESSION_STORAGE_REDIRECT_URL,
+      window.location.pathname
+    );
+  }
 
   return <Navigate to="/" replace={true} />;
 };


### PR DESCRIPTION
Quand on se logout, ça met l'url de callback dans le storage et on ne peut plus se connecter :-/