### PR TITLE
fix(étiquettes): masque l'impression des étiquettes en l'absence de type de plan

### DIFF
--- a/frontend/src/views/SampleView/DraftSample/ContextStep/ContextStep.tsx
+++ b/frontend/src/views/SampleView/DraftSample/ContextStep/ContextStep.tsx
@@ -824,7 +824,7 @@ const ContextStep = ({ partialSample }: Props) => {
             </ul>
           )}
         </div>
-        {isOnline && !readonly && (
+        {isOnline && !readonly && programmingPlanKind && (
           <SupportDocumentDownload partialSample={partialSample ?? formData} />
         )}
       </div>


### PR DESCRIPTION
Résout l'erreur suivante lors de l'impression d'étiquettes DAOA sans avoir choisi un type de plan
Invalid option: expected one of \"PPV\"|\"DAOA_VOLAILLE\"|\"DAOA_BOVIN\"