### PR TITLE
refactor(api): supprime les coerces qui rendaient le typage trop laxiste

### DIFF
--- a/frontend/src/services/api.builder.ts
+++ b/frontend/src/services/api.builder.ts
@@ -6,10 +6,10 @@ import type { MaestroRoutes } from 'maestro-shared/routes/routes';
 import { routes } from 'maestro-shared/routes/routes';
 import type {
   OrEmpty,
-  ClientRouteBody as RouteBody,
-  ClientRouteParams as RouteParams,
-  ClientRouteQuery as RouteQuery,
-  ClientRouteResponse as RouteResponse
+  RouteBody,
+  RouteParams,
+  RouteQuery,
+  RouteResponse
 } from 'maestro-shared/routes/routes.infer';
 import type { TagType } from './api.service';
 

--- a/frontend/src/views/AdminView/AnalysisDaiAdminView/AnalysisDaiAdminView.tsx
+++ b/frontend/src/views/AdminView/AnalysisDaiAdminView/AnalysisDaiAdminView.tsx
@@ -37,8 +37,10 @@ export const AnalysisDaiAdminView = () => {
     laboratoryIds: filters.laboratoryIds.length
       ? filters.laboratoryIds
       : undefined,
-    sentDateFrom: filters.sentDateFrom,
-    sentDateTo: filters.sentDateTo,
+    sentDateFrom: filters.sentDateFrom
+      ? new Date(filters.sentDateFrom)
+      : undefined,
+    sentDateTo: filters.sentDateTo ? new Date(filters.sentDateTo) : undefined,
     edi: filters.edi,
     page,
     perPage: defaultPerPage

--- a/frontend/src/views/SampleListView/SampleListView.tsx
+++ b/frontend/src/views/SampleListView/SampleListView.tsx
@@ -22,11 +22,7 @@ import {
   UserRoleList,
   UserRolePermissions
 } from 'maestro-shared/schema/User/UserRole';
-import {
-  coerceToBooleanNullish,
-  isDefinedAndNotNull,
-  toArray
-} from 'maestro-shared/utils/utils';
+import { isDefinedAndNotNull, toArray } from 'maestro-shared/utils/utils';
 import { useContext, useEffect, useMemo, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router';
 import { AppPage } from 'src/components/_app/AppPage/AppPage';
@@ -115,9 +111,11 @@ const SampleListView = () => {
         laboratoryIds:
           searchParams.get('laboratoryIds')?.split(',') ?? undefined,
         withAtLeastOneResidue:
-          coerceToBooleanNullish().safeParse(
-            searchParams.get('withAtLeastOneResidue')
-          ).data ?? undefined,
+          (['true', 'false'].includes(
+            searchParams.get('withAtLeastOneResidue') ?? ''
+          )
+            ? searchParams.get('withAtLeastOneResidue') === 'true'
+            : undefined) ?? undefined,
         page: Number(searchParams.get('page')) || 1,
         perPage: defaultPerPage
       })

--- a/frontend/src/views/SampleView/DraftSample/ItemsStep/ItemsStep.tsx
+++ b/frontend/src/views/SampleView/DraftSample/ItemsStep/ItemsStep.tsx
@@ -69,7 +69,7 @@ const ItemsStep = ({ partialSample }: Props) => {
     region: isCreatedPartialSample(partialSample)
       ? partialSample.region
       : (user?.region as Region),
-    includes: 'laboratories' as const
+    includes: ['laboratories' as const]
   };
 
   const { data: localPrescriptionByRegion } =

--- a/server/middlewares/validator.ts
+++ b/server/middlewares/validator.ts
@@ -1,6 +1,6 @@
 import type { Request } from 'express';
 import sanitizeHtml from 'sanitize-html';
-import type { ZodObject, z } from 'zod';
+import { type ZodObject, type ZodType, z } from 'zod';
 
 const sanitizeObject = (obj: unknown): any => {
   if (typeof obj === 'string') {
@@ -27,14 +27,85 @@ const sanitizeObject = (obj: unknown): any => {
   return obj;
 };
 
+// Les valeurs de req.query / req.params arrivent toujours en string (ou string[]).
+// Plutôt que de polluer les schémas Zod partagés avec `z.coerce.*`, on coerce ici
+// en walkant la forme attendue par le schéma.
+const unwrap = (schema: ZodType): ZodType => {
+  let s: ZodType = schema;
+  while (
+    s instanceof z.ZodOptional ||
+    s instanceof z.ZodNullable ||
+    s instanceof z.ZodDefault
+  ) {
+    s = (s as z.ZodOptional<ZodType>).unwrap();
+  }
+  return s;
+};
+
+const coerceLeaf = (value: unknown, schema: ZodType): unknown => {
+  if (value === undefined || value === null) return value;
+  const inner = unwrap(schema);
+
+  if (inner instanceof z.ZodArray) {
+    const arr = Array.isArray(value)
+      ? value
+      : typeof value === 'string'
+        ? value.split(',')
+        : [value];
+    return arr.map((v) => coerceLeaf(v, inner.element as ZodType));
+  }
+  if (inner instanceof z.ZodDate && typeof value === 'string') {
+    return new Date(value);
+  }
+  if (inner instanceof z.ZodNumber && typeof value === 'string') {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : value;
+  }
+  if (inner instanceof z.ZodBoolean) {
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+  }
+  return value;
+};
+
+const coerceForSchema = (
+  value: unknown,
+  schema: ZodType | undefined
+): unknown => {
+  if (!schema) return value;
+  const inner = unwrap(schema);
+  if (!(inner instanceof z.ZodObject)) return value;
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return value;
+  }
+  const obj = value as Record<string, unknown>;
+  const shape = inner.shape as Record<string, ZodType>;
+  const result: Record<string, unknown> = { ...obj };
+  for (const key of Object.keys(shape)) {
+    if (key in obj) {
+      result[key] = coerceLeaf(obj[key], shape[key]);
+    }
+  }
+  return result;
+};
+
 export const validateRequest = async <T extends ZodObject>(
   req: Request,
   schema: T,
   options: { skipSanitization: boolean }
 ): Promise<z.infer<T>> => {
+  const shape = schema.shape as Record<string, ZodType | undefined>;
+  const query = options.skipSanitization
+    ? req.query
+    : sanitizeObject(req.query);
+  const params = options.skipSanitization
+    ? req.params
+    : sanitizeObject(req.params);
+  const body = options.skipSanitization ? req.body : sanitizeObject(req.body);
+
   return schema.parseAsync({
-    body: options.skipSanitization ? req.body : sanitizeObject(req.body),
-    query: options.skipSanitization ? req.query : sanitizeObject(req.query),
-    params: options.skipSanitization ? req.params : sanitizeObject(req.params)
+    body,
+    query: coerceForSchema(query, shape.query),
+    params: coerceForSchema(params, shape.params)
   });
 };

--- a/server/middlewares/validator.ts
+++ b/server/middlewares/validator.ts
@@ -29,7 +29,6 @@ const sanitizeObject = (obj: unknown): any => {
 
 // Les valeurs de req.query / req.params arrivent toujours en string (ou string[]).
 // Plutôt que de polluer les schémas Zod partagés avec `z.coerce.*`, on coerce ici
-// en walkant la forme attendue par le schéma.
 const unwrap = (schema: ZodType): ZodType => {
   let s: ZodType = schema;
   while (

--- a/server/routers/routes.type.ts
+++ b/server/routers/routes.type.ts
@@ -14,10 +14,10 @@ import {
 } from 'maestro-shared/routes/routes';
 import type {
   OrEmpty,
-  ServerRouteBody as RouteBody,
-  ServerRouteParams as RouteParams,
-  ServerRouteQuery as RouteQuery,
-  ServerRouteResponse as RouteResponse
+  RouteBody,
+  RouteParams,
+  RouteQuery,
+  RouteResponse
 } from 'maestro-shared/routes/routes.infer';
 import type { TokenPayload } from 'maestro-shared/schema/User/TokenPayload';
 import { hasPermission, type UserBase } from 'maestro-shared/schema/User/User';

--- a/shared/routes/programmingPlans.routes.ts
+++ b/shared/routes/programmingPlans.routes.ts
@@ -72,7 +72,7 @@ export const programmingPlansRoutes = {
   },
   '/programming-plans/years/:year': {
     params: {
-      year: z.coerce.number().int()
+      year: z.number().int()
     },
     post: {
       permissions: ['manageProgrammingPlan'],

--- a/shared/routes/routes.infer.ts
+++ b/shared/routes/routes.infer.ts
@@ -2,88 +2,33 @@ import type z from 'zod';
 import type { ZodType } from 'zod';
 import type { MaestroRoutes, routes } from './routes';
 
-type Side = 'client' | 'server';
+export type InferZod<T> = T extends ZodType ? z.infer<T> : never;
 
-type InferZod<T, Mode extends 'input' | 'output'> = T extends ZodType
-  ? Mode extends 'input'
-    ? z.input<T>
-    : z.output<T>
-  : never;
-
-// Pour body/query/params : le client envoie de l'input, le serveur reçoit de l'output.
-type RequestMode<S extends Side> = S extends 'client' ? 'input' : 'output';
-// Pour response : le client reçoit de l'output, le serveur retourne de l'input (parsé ensuite).
-type ResponseMode<S extends Side> = S extends 'client' ? 'output' : 'input';
-
-type RouteResponse<
+export type RouteResponse<
   P extends MaestroRoutes,
-  M extends keyof (typeof routes)[P],
-  S extends Side
-> = (typeof routes)[P][M] extends { response: infer R }
-  ? InferZod<R, ResponseMode<S>>
-  : never;
+  M extends keyof (typeof routes)[P]
+> = (typeof routes)[P][M] extends { response: infer R } ? InferZod<R> : never;
 
-type RouteBody<
+export type RouteBody<
   P extends MaestroRoutes,
-  M extends keyof (typeof routes)[P],
-  S extends Side
-> = (typeof routes)[P][M] extends { body: infer B }
-  ? InferZod<B, RequestMode<S>>
-  : never;
+  M extends keyof (typeof routes)[P]
+> = (typeof routes)[P][M] extends { body: infer B } ? InferZod<B> : never;
 
-type RouteQuery<
+export type RouteQuery<
   P extends MaestroRoutes,
-  M extends keyof (typeof routes)[P],
-  S extends Side
-> = (typeof routes)[P][M] extends { query: infer Q }
-  ? InferZod<Q, RequestMode<S>>
-  : never;
+  M extends keyof (typeof routes)[P]
+> = (typeof routes)[P][M] extends { query: infer Q } ? InferZod<Q> : never;
 
-type RouteParams<
-  P extends MaestroRoutes,
-  S extends Side
-> = (typeof routes)[P] extends { params: infer Params }
+export type RouteParams<P extends MaestroRoutes> = (typeof routes)[P] extends {
+  params: infer Params;
+}
   ? Params extends undefined
     ? never
     : {
         [K in keyof Params]: Params[K] extends ZodType
-          ? InferZod<Params[K], RequestMode<S>>
+          ? z.infer<Params[K]>
           : never;
       }
   : never;
-
-export type ClientRouteResponse<
-  P extends MaestroRoutes,
-  M extends keyof (typeof routes)[P]
-> = RouteResponse<P, M, 'client'>;
-export type ClientRouteBody<
-  P extends MaestroRoutes,
-  M extends keyof (typeof routes)[P]
-> = RouteBody<P, M, 'client'>;
-export type ClientRouteQuery<
-  P extends MaestroRoutes,
-  M extends keyof (typeof routes)[P]
-> = RouteQuery<P, M, 'client'>;
-export type ClientRouteParams<P extends MaestroRoutes> = RouteParams<
-  P,
-  'client'
->;
-
-export type ServerRouteResponse<
-  P extends MaestroRoutes,
-  M extends keyof (typeof routes)[P]
-> = RouteResponse<P, M, 'server'>;
-export type ServerRouteBody<
-  P extends MaestroRoutes,
-  M extends keyof (typeof routes)[P]
-> = RouteBody<P, M, 'server'>;
-export type ServerRouteQuery<
-  P extends MaestroRoutes,
-  M extends keyof (typeof routes)[P]
-> = RouteQuery<P, M, 'server'>;
-export type ServerRouteParams<P extends MaestroRoutes> = RouteParams<
-  P,
-  'server'
->;
 
 export type OrEmpty<T> = [T] extends [never] ? Record<never, never> : T;

--- a/shared/routes/samples.routes.ts
+++ b/shared/routes/samples.routes.ts
@@ -47,8 +47,8 @@ export const samplesRoutes = {
   '/samples/:sampleId/items/:itemNumber/copy/:copyNumber/document': {
     params: {
       sampleId: z.guid(),
-      itemNumber: z.coerce.number().min(1),
-      copyNumber: z.coerce.number().min(1)
+      itemNumber: z.number().min(1),
+      copyNumber: z.number().min(1)
     },
     get: {
       permissions: ['downloadSupportDocument'],
@@ -58,8 +58,8 @@ export const samplesRoutes = {
   '/samples/:sampleId/items/:itemNumber/copy/:copyNumber': {
     params: {
       sampleId: z.guid(),
-      itemNumber: z.coerce.number().min(1),
-      copyNumber: z.coerce.number().min(1)
+      itemNumber: z.number().min(1),
+      copyNumber: z.number().min(1)
     },
     put: {
       body: SampleItemUpdate,

--- a/shared/schema/Analysis/Analysis.ts
+++ b/shared/schema/Analysis/Analysis.ts
@@ -6,8 +6,8 @@ import { PartialResidue, ResidueChecked } from './Residue/Residue';
 export const PartialAnalysis = z.object({
   id: z.guid(),
   ...SampleItemKey.shape,
-  createdAt: z.coerce.date(),
-  emailReceivedAt: z.coerce.date().nullish(),
+  createdAt: z.date(),
+  emailReceivedAt: z.date().nullish(),
   createdBy: z.guid().nullish(),
   status: AnalysisStatus,
   residues: z.array(PartialResidue).nullish(),

--- a/shared/schema/AnalysisDai/AnalysisDai.ts
+++ b/shared/schema/AnalysisDai/AnalysisDai.ts
@@ -7,7 +7,7 @@ export type AnalysisDaiId = z.infer<typeof AnalysisDaiId>;
 const analysisDaiBase = {
   id: AnalysisDaiId,
   analysisId: z.guid(),
-  createdAt: z.coerce.date()
+  createdAt: z.date()
 };
 
 export const AnalysisDai = z.discriminatedUnion('state', [

--- a/shared/schema/AnalysisDai/AnalysisDaiAnalysisGroup.ts
+++ b/shared/schema/AnalysisDai/AnalysisDaiAnalysisGroup.ts
@@ -8,7 +8,7 @@ import { AnalysisDaiSentMethod } from './AnalysisDaiSentMethod';
 const analysisDaiAttemptBase = {
   id: AnalysisDaiId,
   analysisId: z.guid(),
-  createdAt: z.coerce.date(),
+  createdAt: z.date(),
   documents: z.array(
     z.object({ id: z.guid(), filename: z.string(), kind: DocumentKind })
   )
@@ -22,14 +22,14 @@ export const AnalysisDaiAttempt = z.discriminatedUnion('state', [
     message: z.string(),
     sentMethod: AnalysisDaiSentMethod.nullable(),
     edi: z.boolean().nullable(),
-    sentAt: z.coerce.date()
+    sentAt: z.date()
   }),
   z.object({
     ...analysisDaiAttemptBase,
     state: z.literal('SENT'),
     sentMethod: AnalysisDaiSentMethod,
     edi: z.boolean(),
-    sentAt: z.coerce.date()
+    sentAt: z.date()
   })
 ]);
 
@@ -42,7 +42,7 @@ export const AnalysisDaiAnalysisGroup = z.object({
   sampleItem: z.object({ substanceKind: SubstanceKind }),
   laboratory: Laboratory.nullable(),
   attempts: z.array(AnalysisDaiAttempt),
-  latestAttemptAt: z.coerce.date()
+  latestAttemptAt: z.date()
 });
 
 export type AnalysisDaiAnalysisGroup = z.infer<typeof AnalysisDaiAnalysisGroup>;

--- a/shared/schema/AnalysisDai/FindAnalysisDaiOptions.ts
+++ b/shared/schema/AnalysisDai/FindAnalysisDaiOptions.ts
@@ -1,17 +1,16 @@
 import { z } from 'zod';
-import { coerceToArray, coerceToBooleanNullish } from '../../utils/utils';
 import { Pagination } from '../commons/Pagination';
 import { AnalysisDaiSentMethod } from './AnalysisDaiSentMethod';
 import { AnalysisDaiState } from './AnalysisDaiState';
 
 export const FindAnalysisDaiOptions = z.object({
-  states: coerceToArray(z.array(AnalysisDaiState)).nullish(),
-  sentDateFrom: z.coerce.date().nullish(),
-  sentDateTo: z.coerce.date().nullish(),
-  laboratoryIds: coerceToArray(z.array(z.guid())).nullish(),
-  edi: coerceToBooleanNullish(),
-  sentMethods: coerceToArray(z.array(AnalysisDaiSentMethod)).nullish(),
-  sampleIds: coerceToArray(z.array(z.guid())).nullish(),
+  states: z.array(AnalysisDaiState).nullish(),
+  sentDateFrom: z.date().nullish(),
+  sentDateTo: z.date().nullish(),
+  laboratoryIds: z.array(z.guid()).nullish(),
+  edi: z.boolean().nullish(),
+  sentMethods: z.array(AnalysisDaiSentMethod).nullish(),
+  sampleIds: z.array(z.guid()).nullish(),
   ...Pagination.partial().shape
 });
 

--- a/shared/schema/Company/FindCompanyOptions.ts
+++ b/shared/schema/Company/FindCompanyOptions.ts
@@ -1,13 +1,12 @@
 import { z } from 'zod';
 import { Department } from '../../referential/Department';
 import { Region } from '../../referential/Region';
-import { coerceToArray } from '../../utils/utils';
 import { CompanyKind } from './CompanyKind';
 
 export const FindCompanyOptions = z.object({
   region: Region.nullish(),
   department: Department.nullish(),
-  kinds: coerceToArray(z.array(CompanyKind)).nullish()
+  kinds: z.array(CompanyKind).nullish()
 });
 
 export type FindCompanyOptions = z.infer<typeof FindCompanyOptions>;

--- a/shared/schema/Document/Document.ts
+++ b/shared/schema/Document/Document.ts
@@ -34,7 +34,7 @@ export const documentChecks: CheckFn<
 const DocumentBase = z.object({
   id: z.guid(),
   filename: z.string(),
-  createdAt: z.coerce.date(),
+  createdAt: z.date(),
   createdBy: z.guid().nullish(),
   name: z.string().nullish(),
   kind: DocumentKind,

--- a/shared/schema/Document/FindDocumentOptions.ts
+++ b/shared/schema/Document/FindDocumentOptions.ts
@@ -1,13 +1,12 @@
 import { z } from 'zod';
-import { coerceToArray } from '../../utils/utils';
 import { DocumentKind } from './DocumentKind';
 
 export const FindDocumentOptions = z.object({
-  kinds: coerceToArray(z.array(DocumentKind)).nullish(),
+  kinds: z.array(DocumentKind).nullish(),
   sampleId: z.guid().nullish(),
-  programmingPlanIds: coerceToArray(z.array(z.guid())).nullish(),
-  includeNoProgrammingPlan: z.coerce.boolean().nullish(),
-  year: z.coerce.number().int().nullish()
+  programmingPlanIds: z.array(z.guid()).nullish(),
+  includeNoProgrammingPlan: z.boolean().nullish(),
+  year: z.number().int().nullish()
 });
 
 export type FindDocumentOptions = z.infer<typeof FindDocumentOptions>;

--- a/shared/schema/Laboratory/FindLaboratoryOptions.ts
+++ b/shared/schema/Laboratory/FindLaboratoryOptions.ts
@@ -1,10 +1,9 @@
 import { z } from 'zod';
-import { coerceToArray } from '../../utils/utils';
 import { ProgrammingPlanKind } from '../ProgrammingPlan/ProgrammingPlanKind';
 import { SubstanceKind } from '../Substance/SubstanceKind';
 
 export const FindLaboratoryOptions = z.object({
-  programmingPlanIds: coerceToArray(z.array(z.guid())).nullish(),
+  programmingPlanIds: z.array(z.guid()).nullish(),
   substanceKind: SubstanceKind.nullish(),
   programmingPlanKind: ProgrammingPlanKind.nullish()
 });

--- a/shared/schema/LocalPrescription/FindLocalPrescriptionOptions.ts
+++ b/shared/schema/LocalPrescription/FindLocalPrescriptionOptions.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 import { Department } from '../../referential/Department';
 import { Region } from '../../referential/Region';
-import { coerceToArray } from '../../utils/utils';
 import { ProgrammingPlanContext } from '../ProgrammingPlan/Context';
 import { ProgrammingPlanKind } from '../ProgrammingPlan/ProgrammingPlanKind';
 
@@ -18,17 +17,12 @@ export type LocalPrescriptionOptionsInclude = z.infer<
 export const FindLocalPrescriptionOptions = z.object({
   programmingPlanId: z.guid(),
   prescriptionId: z.guid().nullish(),
-  programmingPlanKinds: coerceToArray(z.array(ProgrammingPlanKind)).nullish(),
-  contexts: coerceToArray(z.array(ProgrammingPlanContext)).nullish(),
+  programmingPlanKinds: z.array(ProgrammingPlanKind).nullish(),
+  contexts: z.array(ProgrammingPlanContext).nullish(),
   region: Region.nullish(),
   department: Department.nullish(),
-  companySirets: coerceToArray(z.array(z.string())).nullish(),
-  includes: z
-    .union([
-      LocalPrescriptionOptionsInclude,
-      coerceToArray(z.array(LocalPrescriptionOptionsInclude))
-    ])
-    .nullish()
+  companySirets: z.array(z.string()).nullish(),
+  includes: z.array(LocalPrescriptionOptionsInclude).nullish()
 });
 
 export type FindLocalPrescriptionOptions = z.infer<

--- a/shared/schema/Prescription/FindPrescriptionOptions.ts
+++ b/shared/schema/Prescription/FindPrescriptionOptions.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
 import { Stage } from '../../referential/Stage';
-import { coerceToArray } from '../../utils/utils';
 import { ProgrammingPlanContext } from '../ProgrammingPlan/Context';
 import { ProgrammingPlanKind } from '../ProgrammingPlan/ProgrammingPlanKind';
 
@@ -12,16 +11,11 @@ export type PrescriptionOptionsInclude = z.infer<
 
 export const FindPrescriptionOptions = z.object({
   programmingPlanId: z.guid(),
-  programmingPlanKinds: coerceToArray(z.array(ProgrammingPlanKind)).nullish(),
-  contexts: coerceToArray(z.array(ProgrammingPlanContext)).nullish(),
+  programmingPlanKinds: z.array(ProgrammingPlanKind).nullish(),
+  contexts: z.array(ProgrammingPlanContext).nullish(),
   matrixKind: z.string().nullish(),
   stage: Stage.nullish(),
-  includes: z
-    .union([
-      PrescriptionOptionsInclude,
-      coerceToArray(z.array(PrescriptionOptionsInclude))
-    ])
-    .nullish()
+  includes: z.array(PrescriptionOptionsInclude).nullish()
 });
 
 export type FindPrescriptionOptions = z.infer<typeof FindPrescriptionOptions>;

--- a/shared/schema/ProgrammingPlan/FindProgrammingPlanOptions.ts
+++ b/shared/schema/ProgrammingPlan/FindProgrammingPlanOptions.ts
@@ -2,7 +2,6 @@ import { intersection } from 'lodash-es';
 import { z } from 'zod';
 import { Department } from '../../referential/Department';
 import { Region } from '../../referential/Region';
-import { coerceToArray } from '../../utils/utils';
 import type { Laboratory } from '../Laboratory/Laboratory';
 import { hasPermission, type UserRefined } from '../User/User';
 import {
@@ -20,10 +19,10 @@ import {
   ProgrammingPlanStatusPermissions
 } from './ProgrammingPlanStatus';
 export const FindProgrammingPlanOptions = z.object({
-  ids: coerceToArray(z.array(z.string().guid())).nullish(),
-  kinds: coerceToArray(z.array(ProgrammingPlanKind)).nullish(),
-  year: z.coerce.number().int().nullish(),
-  status: coerceToArray(z.array(ProgrammingPlanStatus)).nullish(),
+  ids: z.array(z.string().guid()).nullish(),
+  kinds: z.array(ProgrammingPlanKind).nullish(),
+  year: z.number().int().nullish(),
+  status: z.array(ProgrammingPlanStatus).nullish(),
   region: Region.nullish(),
   department: Department.nullish()
 });

--- a/shared/schema/Sample/FindSampleOptions.ts
+++ b/shared/schema/Sample/FindSampleOptions.ts
@@ -3,7 +3,6 @@ import { Department } from '../../referential/Department';
 import { Matrix } from '../../referential/Matrix/Matrix';
 import { MatrixKind } from '../../referential/Matrix/MatrixKind';
 import { Region } from '../../referential/Region';
-import { coerceToArray, coerceToBooleanNullish } from '../../utils/utils';
 import { Pagination } from '../commons/Pagination';
 import { Context } from '../ProgrammingPlan/Context';
 import { ProgrammingPlanKind } from '../ProgrammingPlan/ProgrammingPlanKind';
@@ -18,21 +17,21 @@ import { SampleCompliance } from './SampleCompliance';
 import { SampleStatus } from './SampleStatus';
 
 export const FindSampleOptions = z.object({
-  programmingPlanIds: coerceToArray(z.array(z.guid())).nullish(),
-  kinds: coerceToArray(z.array(ProgrammingPlanKind)).nullish(),
-  contexts: coerceToArray(z.array(Context)).nullish(),
-  regions: coerceToArray(z.array(Region)).nullish(),
-  departments: coerceToArray(z.array(Department)).nullish(),
-  companySirets: coerceToArray(z.array(z.string())).nullish(),
-  statuses: coerceToArray(z.array(SampleStatus)).nullish(),
-  matrices: coerceToArray(z.array(Matrix)).nullish(),
-  matrixKinds: coerceToArray(z.array(MatrixKind)).nullish(),
-  sampledBy: coerceToArray(z.array(z.guid())).nullish(),
+  programmingPlanIds: z.array(z.guid()).nullish(),
+  kinds: z.array(ProgrammingPlanKind).nullish(),
+  contexts: z.array(Context).nullish(),
+  regions: z.array(Region).nullish(),
+  departments: z.array(Department).nullish(),
+  companySirets: z.array(z.string()).nullish(),
+  statuses: z.array(SampleStatus).nullish(),
+  matrices: z.array(Matrix).nullish(),
+  matrixKinds: z.array(MatrixKind).nullish(),
+  sampledBy: z.array(z.guid()).nullish(),
   sampledDate: z.string().nullish(),
   reference: z.string().nullish(),
   compliance: SampleCompliance.nullish(),
-  withAtLeastOneResidue: coerceToBooleanNullish(),
-  laboratoryIds: coerceToArray(z.array(z.guid())).nullish(),
+  withAtLeastOneResidue: z.boolean().nullish(),
+  laboratoryIds: z.array(z.guid()).nullish(),
   prescriptionId: z.guid().nullish(),
   ...Pagination.partial().shape
 });

--- a/shared/schema/User/FindUserOptions.ts
+++ b/shared/schema/User/FindUserOptions.ts
@@ -1,19 +1,18 @@
 import { z } from 'zod';
 import { Department } from '../../referential/Department';
 import { Region } from '../../referential/Region';
-import { coerceToArray, coerceToBooleanNullish } from '../../utils/utils';
 import { ProgrammingPlanKind } from '../ProgrammingPlan/ProgrammingPlanKind';
 import { UserRole } from './UserRole';
 export const FindUserOptions = z.object({
   region: Region.nullish(),
   department: Department.nullish(),
-  roles: coerceToArray(z.array(UserRole)).nullish(),
+  roles: z.array(UserRole).nullish(),
   programmingPlanKinds: z
-    .union([ProgrammingPlanKind, coerceToArray(z.array(ProgrammingPlanKind))])
+    .union([ProgrammingPlanKind, z.array(ProgrammingPlanKind)])
     .nullish(),
-  companySirets: coerceToArray(z.array(z.string())).nullish(),
-  disabled: coerceToBooleanNullish(),
-  laboratoryIds: coerceToArray(z.array(z.string())).nullish()
+  companySirets: z.array(z.string()).nullish(),
+  disabled: z.boolean().nullish(),
+  laboratoryIds: z.array(z.string()).nullish()
 });
 
 export type FindUserOptions = z.infer<typeof FindUserOptions>;

--- a/shared/schema/commons/Pagination.ts
+++ b/shared/schema/commons/Pagination.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 export const Pagination = z.object({
-  page: z.coerce.number().int().positive(),
-  perPage: z.coerce.number().int().positive()
+  page: z.number().int().positive(),
+  perPage: z.number().int().positive()
 });
 
 export type Pagination = z.infer<typeof Pagination>;

--- a/shared/utils/utils.ts
+++ b/shared/utils/utils.ts
@@ -1,35 +1,13 @@
 import { camelCase, flow, isArray, isPlainObject } from 'lodash-es';
-import { z } from 'zod';
 
 export const isDefined = <A>(a: A | undefined): a is A => a !== undefined;
 
 export const isDefinedAndNotNull = <A>(a: A | null | undefined): a is A =>
   a !== null && a !== undefined;
 
-export function coerceToArray<Schema extends z.ZodArray<z.ZodTypeAny>>(
-  schema: Schema
-) {
-  return z
-    .union([z.any().array(), z.any().transform((x) => x?.split(','))])
-    .pipe(schema);
-}
-
 export function toArray<T>(value?: T | T[]): T[] | undefined {
   return Array.isArray(value) ? value : value ? [value] : undefined;
 }
-
-export const coerceToBooleanNullish = () =>
-  z
-    .union([
-      z
-        .enum(['true', 'false'])
-        .nullish()
-        .transform((value) =>
-          value === 'true' ? true : value === 'false' ? false : value
-        ),
-      z.boolean().nullish()
-    ])
-    .nullish();
 
 export const convertKeysToCamelCase = (obj: unknown): unknown => {
   if (!isPlainObject(obj)) {


### PR DESCRIPTION
Hier je suis tombé sur un bug lors de mon dev sur les DAI. 
En gros à cause de coerce on pouvait mettre un peu n'importe quoi dans les params et les queries.
Suppression de tous les coerces et ajout de ceux-ci à la volée dans le backend quand il parse les queries et les params