### PR TITLE
fix(prélèvement): ne peut passer à la 3ème étape si les éléments de la 2ème ne sont pas chargés

### DIFF
--- a/frontend/src/services/mockApiClient.ts
+++ b/frontend/src/services/mockApiClient.ts
@@ -43,7 +43,19 @@ export type MockApi = {
     any,
     any
   >
-    ? { data: D } | ((arg: any) => { data: D })
+    ?
+        | {
+            data: D | undefined;
+            isSuccess?: boolean;
+            isLoading?: boolean;
+            isError?: boolean;
+          }
+        | ((arg: any) => {
+            data: D | undefined;
+            isSuccess?: boolean;
+            isLoading?: boolean;
+            isError?: boolean;
+          })
     : ApiClient[Key] extends TypedUseLazyQuery<infer E, any, any>
       ? [E, { isSuccess?: boolean; isLoading?: boolean; isError?: boolean }]
       : ApiClient[Key] extends TypedUseMutation<any, any, any>
@@ -70,7 +82,13 @@ export const getMockApi = (partialMock: Partial<MockApi>): ApiClient => {
       acc[key] = (arg?: any) => {
         // @ts-expect-error TS7053
         const value = mockApi[key];
-        return typeof value === 'function' ? value(arg) : value;
+        const resolved = typeof value === 'function' ? value(arg) : value;
+        return {
+          isSuccess: resolved.data !== undefined && !resolved.isError,
+          isLoading: resolved.data === undefined && !resolved.isError,
+          isError: false,
+          ...resolved
+        };
       };
     } else if (
       key.startsWith('useLazyGet') ||

--- a/frontend/src/views/SampleView/DraftSample/MatrixStep/MatrixStep.tsx
+++ b/frontend/src/views/SampleView/DraftSample/MatrixStep/MatrixStep.tsx
@@ -110,7 +110,7 @@ const MatrixStep = ({ partialSample }: Props) => {
   const programmingPlanKind =
     partialSample.programmingPlanKind as ProgrammingPlanKind;
 
-  const { data: fieldConfigs = [] } =
+  const { data: fieldConfigs = [], isSuccess: isFieldConfigsLoaded } =
     apiClient.useFindPlanKindFieldConfigsQuery({
       programmingPlanId: partialSample.programmingPlanId,
       kind: programmingPlanKind
@@ -403,6 +403,7 @@ const MatrixStep = ({ partialSample }: Props) => {
                 className={cx('fr-pr-0')}
                 iconId="fr-icon-arrow-right-line"
                 iconPosition="right"
+                disabled={!readonly && !isFieldConfigsLoaded}
                 onClick={async (e) =>
                   readonly ? navigateToSample(partialSample.id, 3) : submit(e)
                 }
@@ -685,6 +686,7 @@ const MatrixStep = ({ partialSample }: Props) => {
                   iconId="fr-icon-arrow-right-line"
                   iconPosition="right"
                   data-testid="submit-button"
+                  disabled={!isFieldConfigsLoaded}
                 >
                   Continuer
                 </Button>

--- a/frontend/src/views/SampleView/DraftSample/MatrixStep/stories/MatrixStepPPV.stories.tsx
+++ b/frontend/src/views/SampleView/DraftSample/MatrixStep/stories/MatrixStepPPV.stories.tsx
@@ -152,6 +152,24 @@ export const MatrixStepPPVWithoutPrescriptions: Story = {
   }
 };
 
+export const MatrixStepPPVFieldConfigsLoading: Story = {
+  ...story,
+  parameters: {
+    ...story.parameters,
+    apiClient: {
+      ...getMockApi({
+        ...storyMockApi,
+        useFindPlanKindFieldConfigsQuery: { data: undefined }
+      })
+    }
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByTestId('submit-button')).toBeDisabled();
+  }
+};
+
 export const MatrixStepPPVSubmittingErrors: Story = {
   ...story,
   play: async ({ canvasElement }) => {

--- a/server/controllers/sampleController.ts
+++ b/server/controllers/sampleController.ts
@@ -451,7 +451,7 @@ export const sampleRouter = {
         return { status: constants.HTTP_STATUS_FORBIDDEN };
       }
 
-      if (['Sent', 'Submitted'].includes(sampleUpdate.step)) {
+      if (['DraftItems', 'Sent', 'Submitted'].includes(sampleUpdate.step)) {
         const fieldConfigs =
           await specificDataFieldConfigRepository.findByPlanKind(
             sampleUpdate.programmingPlanId,

--- a/server/routers/test/sample.router.test.ts
+++ b/server/routers/test/sample.router.test.ts
@@ -664,6 +664,35 @@ describe('Sample router', () => {
         .expect(constants.HTTP_STATUS_BAD_REQUEST);
     });
 
+    test('should be forbidden to move a DAOA_BOVIN sample to DraftItems with incomplete specificData', async () => {
+      const sampleId = uuidv4();
+      const sample = genCreatedPartialSample({
+        id: sampleId,
+        sampler: SamplerDaoaFixture,
+        programmingPlanId: DAOAInProgressProgrammingPlanFixture.id,
+        region: SamplerDaoaFixture.region,
+        department: SamplerDaoaFixture.department,
+        company: SlaughterhouseCompanyFixture1,
+        step: 'Draft',
+        matrixKind: 'A0C0Z',
+        matrix: 'A0BAV',
+        programmingPlanKind: 'DAOA_BOVIN',
+        specificData: {
+          programmingPlanKind: 'DAOA_BOVIN'
+        }
+      });
+      await Samples().insert(formatPartialSample(sample));
+
+      await request(app)
+        .put(`${testRoute(sampleId)}`)
+        .send({
+          ...sample,
+          step: 'DraftItems'
+        })
+        .use(tokenProvider(SamplerDaoaFixture))
+        .expect(constants.HTTP_STATUS_BAD_REQUEST);
+    });
+
     test('should update the sample send date when sending the sample', async () => {
       const successRequestTest = async (user: UserRefined) => {
         await Samples()


### PR DESCRIPTION
Avec une mauvaise connexion, on peut passer de la step 2 à la 3 sans remplir les specifiques data si on attend pas le chargement de celles-ci :
 - Disable de bouton tant que c'est pas chargé
 - Blocage côté backend