### PR TITLE
fix(brevo): cloisonne les destinataires

### DIFF
--- a/server/services/mailService/brevoService.ts
+++ b/server/services/mailService/brevoService.ts
@@ -49,9 +49,10 @@ class BrevoService implements MailService {
       const body = {
         ...options,
         templateId: Templates[options.templateName].id,
-        to: options.recipients.map((recipient) => ({ email: recipient }))
+        messageVersions: options.recipients.map((recipient) => ({
+          to: [{ email: recipient }]
+        }))
       };
-
       const response = await fetch(brevoUrl, {
         method: 'POST',
         headers: this.headers,


### PR DESCRIPTION
On était limité à 99 destinataires, car on envoyait un seul email à plus de 99 personnes.
En faisant comme ça on envoit 99 emails à une seule personne.
Si pas de PJ, nous sommes limités à 2000 emails.
Si PJ, c'est seulement 99 emails.
Mais dans notre cas, à chaque fois qu'on a une PJ on l'envoi à très peu de gens.

Cool :
 - Correction du pb lors d'un ajout d'un document
 - Les destinataires ne se voient plus
 
 Pas cool :
  - On va consommer beaucoup plus vite notre quota (je me demande si on devrait pas revoir notre politique, et seulement envoyer une notif inapp dans certain cas)
  - Si plus tard on ajoute une PJ, on retombera sur le même pb.