### PR TITLE
fix(laboratoires): simplifie la contrainte sur le mode de communication dans la table laboratoires

### DIFF
--- a/frontend/src/views/AdminView/LaboratoriesAdminView/LaboratoryConfigForm.tsx
+++ b/frontend/src/views/AdminView/LaboratoriesAdminView/LaboratoryConfigForm.tsx
@@ -46,8 +46,12 @@ const buildSacha = (state: FormState): SachaConfig | null => {
       ? {
           method: 'EMAIL' as const,
           recipientEmail: state.sachaRecipientEmail,
-          gpgEmail: state.sachaGpgEmail,
-          gpgPublicKey: state.sachaGpgPublicKey
+          gpgEmail:
+            state.sachaGpgEmail.trim() === '' ? null : state.sachaGpgEmail,
+          gpgPublicKey:
+            state.sachaGpgPublicKey.trim() === ''
+              ? null
+              : state.sachaGpgPublicKey
         }
       : state.sachaMethod === 'SFTP'
         ? { method: 'SFTP' as const, sftpLogin: state.sachaSftpLogin }
@@ -84,11 +88,11 @@ const initialState = (lab: LaboratoryWithSacha): FormState => ({
       : '',
   sachaGpgEmail:
     lab.sacha?.communication?.method === 'EMAIL'
-      ? lab.sacha.communication.gpgEmail
+      ? (lab.sacha.communication.gpgEmail ?? '')
       : '',
   sachaGpgPublicKey:
     lab.sacha?.communication?.method === 'EMAIL'
-      ? lab.sacha.communication.gpgPublicKey
+      ? (lab.sacha.communication.gpgPublicKey ?? '')
       : '',
   sachaSftpLogin:
     lab.sacha?.communication?.method === 'SFTP'
@@ -260,7 +264,7 @@ export const LaboratoryConfigForm = ({ laboratory }: Props) => {
                   inputForm={form}
                   inputKey="sacha"
                   inputPathFromKey={['communication', 'gpgEmail']}
-                  required
+                  required={state.sachaActivated}
                 />
               </div>
               <div
@@ -276,7 +280,7 @@ export const LaboratoryConfigForm = ({ laboratory }: Props) => {
                   inputForm={form}
                   inputKey="sacha"
                   inputPathFromKey={['communication', 'gpgPublicKey']}
-                  required
+                  required={state.sachaActivated}
                 />
               </div>
             </>

--- a/server/controllers/laboratoryController.ts
+++ b/server/controllers/laboratoryController.ts
@@ -121,6 +121,7 @@ export const laboratoriesRouter = {
 
       if (
         body.sacha?.communication?.method === 'EMAIL' &&
+        body.sacha.communication.gpgPublicKey &&
         body.sacha.communication.gpgPublicKey !== previousGpgPublicKey
       ) {
         await importPublicKey(body.sacha.communication.gpgPublicKey);

--- a/server/database/migrations/105-laboratory-sacha-email-without-gpg.ts
+++ b/server/database/migrations/105-laboratory-sacha-email-without-gpg.ts
@@ -1,0 +1,59 @@
+import type { Knex } from 'knex';
+
+export const up = async (knex: Knex) => {
+  await knex.raw(
+    'ALTER TABLE laboratories DROP CONSTRAINT laboratories_sacha_consistency_check'
+  );
+
+  await knex.raw(`
+    ALTER TABLE laboratories
+    ADD CONSTRAINT laboratories_sacha_consistency_check CHECK (
+      (legacy_dai = true
+        AND sacha_activated = false
+        AND sacha_communication_method IS NULL
+        AND sacha_recipient_email IS NULL
+        AND sacha_gpg_email IS NULL
+        AND sacha_gpg_public_key IS NULL
+        AND sacha_sftp_login IS NULL
+        AND sacha_sigle IS NULL)
+      OR (legacy_dai = false
+        AND (
+          sacha_communication_method IS NULL
+          OR (sacha_communication_method = 'EMAIL'
+            AND sacha_recipient_email IS NOT NULL)
+          OR (sacha_communication_method = 'SFTP'
+            AND sacha_sftp_login IS NOT NULL)
+        ))
+    )
+  `);
+};
+
+export const down = async (knex: Knex) => {
+  await knex.raw(
+    'ALTER TABLE laboratories DROP CONSTRAINT laboratories_sacha_consistency_check'
+  );
+
+  await knex.raw(`
+    ALTER TABLE laboratories
+    ADD CONSTRAINT laboratories_sacha_consistency_check CHECK (
+      (legacy_dai = true
+        AND sacha_activated = false
+        AND sacha_communication_method IS NULL
+        AND sacha_recipient_email IS NULL
+        AND sacha_gpg_email IS NULL
+        AND sacha_gpg_public_key IS NULL
+        AND sacha_sftp_login IS NULL
+        AND sacha_sigle IS NULL)
+      OR (legacy_dai = false
+        AND (
+          sacha_communication_method IS NULL
+          OR (sacha_communication_method = 'EMAIL'
+            AND sacha_recipient_email IS NOT NULL
+            AND sacha_gpg_email IS NOT NULL
+            AND sacha_gpg_public_key IS NOT NULL)
+          OR (sacha_communication_method = 'SFTP'
+            AND sacha_sftp_login IS NOT NULL)
+        ))
+    )
+  `);
+};

--- a/server/repositories/laboratoryRepository.ts
+++ b/server/repositories/laboratoryRepository.ts
@@ -27,8 +27,8 @@ const buildCommunication = (
       return {
         method: 'EMAIL',
         recipientEmail: row.sachaRecipientEmail!,
-        gpgEmail: row.sachaGpgEmail!,
-        gpgPublicKey: row.sachaGpgPublicKey!
+        gpgEmail: row.sachaGpgEmail,
+        gpgPublicKey: row.sachaGpgPublicKey
       };
     case 'SFTP':
       return { method: 'SFTP', sftpLogin: row.sachaSftpLogin! };
@@ -206,8 +206,8 @@ const buildSachaFields = (sacha: SachaConfig | null) => {
         sachaSigle: sacha.sigle,
         sachaCommunicationMethod: 'EMAIL' as const,
         sachaRecipientEmail: communication.recipientEmail,
-        sachaGpgEmail: communication.gpgEmail,
-        sachaGpgPublicKey: communication.gpgPublicKey,
+        sachaGpgEmail: communication.gpgEmail ?? null,
+        sachaGpgPublicKey: communication.gpgPublicKey ?? null,
         sachaSftpLogin: null
       };
     case 'SFTP':

--- a/server/routers/test/laboratory.router.test.ts
+++ b/server/routers/test/laboratory.router.test.ts
@@ -220,6 +220,25 @@ f2LgSfYvHNZbocMsQoVBhv3yF1i9/Hw=
         .expect(constants.HTTP_STATUS_OK);
     });
 
+    test('should accept a SACHA EMAIL config without GPG', async () => {
+      await request(app)
+        .put(testRoute(LaboratoryFixture.id))
+        .use(tokenProvider(AdminFixture))
+        .send({
+          ...baseBody,
+          legacyDai: false,
+          sacha: {
+            activated: true,
+            sigle: 'LAB1',
+            communication: {
+              method: 'EMAIL',
+              recipientEmail: 'sacha@lab.fr'
+            }
+          }
+        })
+        .expect(constants.HTTP_STATUS_OK);
+    });
+
     test('should accept a valid SACHA SFTP config', async () => {
       await request(app)
         .put(testRoute(LaboratoryFixture.id))

--- a/server/services/ediSacha/sachaSender.ts
+++ b/server/services/ediSacha/sachaSender.ts
@@ -73,6 +73,13 @@ export const sendSachaFile = async (
           'EMAIL'
         );
       }
+      if (!laboratory.sacha.communication.gpgEmail) {
+        throw new DaiProcessingError(
+          "La configuration EMAIL du laboratoire n'a pas de clé GPG",
+          true,
+          'EMAIL'
+        );
+      }
       const encryptFileName = `${zipFileName}.gpg`;
       const encryptFilePath = await encryptFile(
         zipFilePath,

--- a/shared/schema/Laboratory/Laboratory.ts
+++ b/shared/schema/Laboratory/Laboratory.ts
@@ -22,8 +22,8 @@ const SachaCommunication = z.discriminatedUnion('method', [
   z.object({
     method: z.literal(SachaCommunicationMethod.enum.EMAIL),
     recipientEmail: z.email(),
-    gpgEmail: z.email(),
-    gpgPublicKey: z.string()
+    gpgEmail: z.email().nullish(),
+    gpgPublicKey: z.string().nullish()
   }),
   z.object({
     method: z.literal(SachaCommunicationMethod.enum.SFTP),

--- a/shared/test/sampleFixtures.ts
+++ b/shared/test/sampleFixtures.ts
@@ -233,6 +233,7 @@ export const SampleDAOA1Fixture = genCreatedPartialSample({
     x: 46.642117,
     y: -0.734475
   },
+  reference: 'DAOA-85-24-001-A',
   specificData: {}
 });
 export const SampleDAOA2Fixture = genCreatedPartialSample({
@@ -246,5 +247,6 @@ export const SampleDAOA2Fixture = genCreatedPartialSample({
   geolocation: {
     x: 46.642117,
     y: -0.734475
-  }
+  },
+  reference: 'DAOA-85-24-002-A'
 });


### PR DESCRIPTION
J'ai récupéré la plupart des emails pour Sacha, je souhaite les mettre en bdd mais cette contrainte m'en empêche